### PR TITLE
Perfact the index page in demo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -49,6 +49,7 @@ jQuery(function ($) {
       </div>
       <div class="css">
         <h2>Demo CSS: </h2>
+        <a href="https://github.com/jgerigmeyer/jquery-loading-overlay/blob/master/demo/demo.css">Full demo.css to solve the cross-browser compatibility issue</a>
         <pre>
 @font-face {
   font-family: "demo";


### PR DESCRIPTION
- only add a link to full demo.css in working example page

Some time ago, i tried to use this jquery plugin, only copied the css from the working example, and then it had some cross-browser compatibility issues on IE and Safari, which costed me a lot of time because of the keyframes and transform attribute (I don't quite understand the frontend :smile: ). 

But at last, i have found the solution has been added below the project :sob: .

So,  I think it should add a link to full demo.css file to avoid this kind of situation, juse like me :smile: .

Thanks
